### PR TITLE
Fix NotADirectoryError occurring on Unix systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,8 @@ of the comic files.
 The plugin uses the ``image.py`` class from Alex Yatskov's [Mangle](https://github.com/FooSoft/mangle/) 
 with subsequent [proDOOMman's](https://github.com/proDOOMman/Mangle) 
 and [Birua's](https://github.com/Birua/Mangle) patches.
+
+## Considerations for MacOS
+Get kindlegen by installing `kindle-comic-creator` with brew. The executable will be located at this location:
+`/Applications/Kindle Comic Creator/Kindle Comic Creator.app/Contents/MacOS/kindlegen`. Otherwise you might run into
+issues with `kindlegen` being only 32-bit compatible.

--- a/kindle_comics_input/kindle_comic_lib/text_unidecode/__init__.py
+++ b/kindle_comics_input/kindle_comic_lib/text_unidecode/__init__.py
@@ -12,7 +12,7 @@ module_path = os.path.dirname(sys.modules[__name__].__file__)
 zip_path = os.path.join(module_path, '../..')
 path_in_zip = "kindle_comic_lib/text_unidecode/data.bin"
 
-archive = zipfile.ZipFile(zip_path, 'r')
+archive = zipfile.ZipFile(os.path.abspath(zip_path), 'r')
 data = archive.read(path_in_zip)
 
 _replaces = data.decode('utf8').split('\x00')

--- a/kindle_comics_output/build_file.py
+++ b/kindle_comics_output/build_file.py
@@ -1,4 +1,5 @@
 import os
+import stat
 from subprocess import Popen, PIPE, STDOUT
 
 from calibre.ptempfile import PersistentTemporaryDirectory
@@ -144,7 +145,7 @@ def make_mobi(epub_path):
 def get_kindlegen():
     # copy kindlegen to destination
     plugin_path = os.path.join(__file__, "..")
-    plugin_zip = ZipFile(plugin_path)
+    plugin_zip = ZipFile(os.path.abspath(plugin_path))
     kindlegen_path = PersistentTemporaryDirectory("_kindlegen")
 
     if os.name == 'nt':  # Windows
@@ -153,4 +154,7 @@ def get_kindlegen():
         kindlegen_filename = 'kindlegen'
 
     plugin_zip.extract(kindlegen_filename, kindlegen_path)
+    if os.name != 'nt':  # Linux or macOS
+        # Execute permissions needed
+        os.chmod(os.path.join(kindlegen_path, kindlegen_filename), stat.S_IEXEC)
     return os.path.join(kindlegen_path, kindlegen_filename)


### PR DESCRIPTION
Hello,
Tried to use this plugin on MacOS with Calibre and it failed like mentioned in the issues. I fixed the NotADirectoryError on both the input and output plugins.

There was 2 other issues with `kindlegen`.
1. The `kindlegen` binary in the release for MacOS is 32-bit only, which is not working on newer MacOS versions. I added a note on the readme on how to get the binary easily on mac
2. Python `ZipFile.extract` method doesn't replicate file permissions so Popen was failing silently. I modified `get_kindlegen` to force execution permissions on unix systems.

Please test this PR on windows and if you can Linux before merging, as I only tested those changes on MacOS